### PR TITLE
bugfix/#110 Render badge with repository name

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-APP_VERSION=8.2.20
+APP_VERSION=8.2.21
 PAYPAL_URL=https://www.paypal.me/ArtemSolovev
 OPENCOLLECTIVE_URL=https://opencollective.com/artem-solovev

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "short_name": "__MSG_shortName__",
     "author": "__MSG_author__",
     "description": "__MSG_description__",
-    "version": "8.2.20",
+    "version": "8.2.21",
     "browser_action": {
         "default_icon": "img/icon128.png",
         "default_popup": "index.html",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gloc",
-  "version": "8.2.20",
+  "version": "8.2.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gloc",
-  "version": "8.2.20",
+  "version": "8.2.21",
   "description": "Extension counts the number of lines of code in GitHub pages.",
   "author": "Artem Solovev",
   "license": "GPL-2.0",

--- a/src/utils/renderLocs.ts
+++ b/src/utils/renderLocs.ts
@@ -13,12 +13,12 @@ export const renderLocs = (linksData: InitialData, token: string) => {
 
 		if (reponame) {
 			requestLoc(reponame, TRIES_DEFAULT, token)
-				.then(loc => renderLoc(placeToInsert, formatOutput(loc)))
+				.then(loc => renderLoc(placeToInsert, reponame, formatOutput(loc)))
 				.catch(err => console.error(`Error by setting LOC for ${reponame}`, err));
 		}
 	});
 };
 
-const renderLoc = (anchor: HTMLAnchorElement, loc: string) => {
-	anchor.innerHTML += renderBadge(loc);
+const renderLoc = (anchor: HTMLAnchorElement, reponame: string, loc: string) => {
+	anchor.innerHTML = reponame.split('/').slice(-1)[0] + renderBadge(loc);
 };


### PR DESCRIPTION
Fix #110

The upper part of repository detail page is not reloaded when you go into sub directories, so the budge has to be rendered with the repository name.